### PR TITLE
Add GA4 consent banner support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Once the app is running, follow these steps to use the **Where is SWOT?** tool:
 3. **Click "Check SWOT Passings"**: The app will generate a map showing the satellite’s passings for the selected date range.
 4. **View Results**: The map will display the projected path of the SWOT satellite, highlighting its coverage areas.
 
+## Analytics Setup
+
+To enable Google Analytics 4 tracking, set a Hugging Face Space secret named `GA_MEASUREMENT_ID` to your GA4 Measurement ID, for example `G-XXXXXXXXXX`.
+
+The app only loads Google Analytics after a visitor accepts the cookie banner.
+
 ## Contributing
 
 Contributions are welcome! If you'd like to improve this project, follow these steps:

--- a/app.py
+++ b/app.py
@@ -1,18 +1,74 @@
 import os
-from flask import Flask, render_template, request
+import time
+import uuid
+from flask import Flask, abort, render_template, request, send_file, url_for
 import geopandas as gpd
 import pandas as pd
 from datetime import timedelta, datetime
 from tools import process_orbit_data, create_map
 
 app = Flask(__name__)
+MAP_CACHE_DIR = "/tmp/whereisswot-maps"
+MAP_MAX_AGE_SECONDS = 3600
+GA_MEASUREMENT_ID = os.getenv("GA_MEASUREMENT_ID")
 
 orbit_data = process_orbit_data()
 eez = gpd.read_file('data/external/eez/eez_boundaries_v12.shp').drop(columns=["DOC_DATE"])
 
+
+def cleanup_old_maps():
+    """Best-effort cleanup for stale generated map files."""
+    os.makedirs(MAP_CACHE_DIR, exist_ok=True)
+    now = time.time()
+    for filename in os.listdir(MAP_CACHE_DIR):
+        if not filename.endswith(".html"):
+            continue
+        path = os.path.join(MAP_CACHE_DIR, filename)
+        try:
+            if now - os.path.getmtime(path) > MAP_MAX_AGE_SECONDS:
+                os.remove(path)
+        except FileNotFoundError:
+            continue
+
+
+def store_map_html(map_html):
+    os.makedirs(MAP_CACHE_DIR, exist_ok=True)
+    cleanup_old_maps()
+    if GA_MEASUREMENT_ID:
+        analytics_snippet = f"""
+<script>
+  (function () {{
+    const gaId = {GA_MEASUREMENT_ID!r};
+    if (!gaId || localStorage.getItem('analytics_consent') !== 'accepted' || window.gaLoaded) {{
+      return;
+    }}
+
+    window.gaLoaded = true;
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=' + gaId;
+    document.head.appendChild(script);
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {{ dataLayer.push(arguments); }}
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', gaId, {{ 'page_title': 'SWOT Satellite Passings Map' }});
+  }})();
+</script>
+</body>
+"""
+        map_html = map_html.replace("</body>", analytics_snippet)
+
+    map_id = f"{uuid.uuid4().hex}.html"
+    map_path = os.path.join(MAP_CACHE_DIR, map_id)
+    with open(map_path, "w", encoding="utf-8") as f:
+        f.write(map_html)
+    return map_id
+
 @app.route("/", methods=["GET", "POST"])
 def index():
-    map_html = None
+    map_url = None
     start_date_str = None
     num_days_str = "5"
 
@@ -26,14 +82,14 @@ def index():
             try:
                 start_date = pd.to_datetime(start_date_str)
             except ValueError:
-                return render_template("index.html", map_html=None, message="Invalid date format", start_date=start_date_str, num_days=num_days_str)
+                return render_template("index.html", map_url=None, message="Invalid date format", start_date=start_date_str, num_days=num_days_str, ga_measurement_id=GA_MEASUREMENT_ID)
 
         try:
             num_days = int(num_days_str)
             if num_days > 100:
-                return render_template("index.html", map_html=None, message="Number of days must not exceed 100.", start_date=start_date_str, num_days=num_days_str)
+                return render_template("index.html", map_url=None, message="Number of days must not exceed 100.", start_date=start_date_str, num_days=num_days_str, ga_measurement_id=GA_MEASUREMENT_ID)
         except ValueError:
-            return render_template("index.html", map_html=None, message="Invalid number of days format", start_date=start_date_str, num_days=num_days_str)
+            return render_template("index.html", map_url=None, message="Invalid number of days format", start_date=start_date_str, num_days=num_days_str, ga_measurement_id=GA_MEASUREMENT_ID)
 
         end_date = start_date + timedelta(days=num_days)
 
@@ -47,13 +103,26 @@ def index():
         map_object, selected = create_map(start_date, end_date, orbit_data, opacity=opacity, fill_opacity=fill_opacity, eez=eez)
 
         if selected is None or selected.empty:
-            return render_template("index.html", map_html=None, message="No data available for the selected date range.", start_date=start_date_str, num_days=num_days_str)
+            return render_template("index.html", map_url=None, message="No data available for the selected date range.", start_date=start_date_str, num_days=num_days_str, ga_measurement_id=GA_MEASUREMENT_ID)
 
-        map_html = map_object.get_root().render()
+        map_id = store_map_html(map_object.get_root().render())
+        map_url = url_for("show_map", map_id=map_id)
 
-        return render_template("index.html", map_html=map_html, message=None, start_date=start_date_str, num_days=num_days_str)
+        return render_template("index.html", map_url=map_url, message=None, start_date=start_date_str, num_days=num_days_str, ga_measurement_id=GA_MEASUREMENT_ID)
 
-    return render_template("index.html", map_html=None, message=None, start_date=start_date_str, num_days=num_days_str)
+    return render_template("index.html", map_url=None, message=None, start_date=start_date_str, num_days=num_days_str, ga_measurement_id=GA_MEASUREMENT_ID)
+
+
+@app.route("/show_map/<path:map_id>")
+def show_map(map_id):
+    cleanup_old_maps()
+    map_path = os.path.abspath(os.path.join(MAP_CACHE_DIR, map_id))
+    cache_dir = os.path.abspath(MAP_CACHE_DIR)
+
+    if not map_path.startswith(f"{cache_dir}{os.sep}") or not os.path.exists(map_path):
+        abort(404)
+
+    return send_file(map_path, mimetype="text/html")
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=4242)

--- a/templates/index.html
+++ b/templates/index.html
@@ -65,6 +65,33 @@
             width: 3rem;
             height: 3rem;
         }
+        .cookie-banner {
+            position: fixed;
+            left: 50%;
+            bottom: 20px;
+            transform: translateX(-50%);
+            max-width: 420px;
+            width: calc(100% - 40px);
+            padding: 16px;
+            background: rgba(33, 37, 41, 0.96);
+            color: #fff;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+            z-index: 1050;
+        }
+        .cookie-banner[data-state="visible"] {
+            display: block !important;
+        }
+        .cookie-banner p {
+            margin-bottom: 12px;
+        }
+        .cookie-actions {
+            display: flex;
+            gap: 10px;
+        }
+        .cookie-actions .btn {
+            flex: 1;
+        }
     </style>
 </head>
 <body>
@@ -132,19 +159,88 @@
         {% endif %}
 
         <!-- Map Container -->
-        {% if map_html %}
+        {% if map_url %}
             <div class="map-container">
                 <h2 class="text-center">SWOT Satellite Passings Map</h2>
-                <iframe srcdoc="{{ map_html | e }}" class="w-100" height="600px" frameborder="0"></iframe>
+                <iframe src="{{ map_url }}" class="w-100" height="600px" frameborder="0"></iframe>
             </div>
         {% endif %}
     </div>
 
+    <div id="cookie-banner" class="cookie-banner" style="display: none;">
+        <p>This site uses analytics cookies to understand how people use the tool and improve it over time. You can accept or decline analytics tracking.</p>
+        <div class="cookie-actions">
+            <button type="button" class="btn btn-primary" id="accept-cookies">Accept</button>
+            <button type="button" class="btn btn-outline-light" id="decline-cookies">Decline</button>
+        </div>
+    </div>
+
     <!-- Loading Spinner JavaScript -->
     <script>
+        const GA_MEASUREMENT_ID = {{ ga_measurement_id|tojson }};
+
+        function loadGoogleAnalytics() {
+            if (!GA_MEASUREMENT_ID || window.gaLoaded) {
+                return;
+            }
+
+            window.gaLoaded = true;
+            const script = document.createElement('script');
+            script.async = true;
+            script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+            document.head.appendChild(script);
+
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){ dataLayer.push(arguments); }
+            window.gtag = gtag;
+            gtag('js', new Date());
+            gtag('config', GA_MEASUREMENT_ID);
+        }
+
+        function hideCookieBanner() {
+            document.getElementById('cookie-banner').style.display = 'none';
+            document.getElementById('cookie-banner').dataset.state = 'hidden';
+        }
+
+        function showCookieBanner() {
+            document.getElementById('cookie-banner').style.display = 'block';
+            document.getElementById('cookie-banner').dataset.state = 'visible';
+        }
+
         // Show spinner when form is submitted
         document.querySelector('form').addEventListener('submit', function() {
             document.getElementById('loading').style.display = 'block';
+        });
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if (!GA_MEASUREMENT_ID) {
+                return;
+            }
+
+            const consent = localStorage.getItem('analytics_consent');
+            if (consent === 'accepted') {
+                loadGoogleAnalytics();
+                hideCookieBanner();
+                return;
+            }
+
+            if (consent === 'declined') {
+                hideCookieBanner();
+                return;
+            }
+
+            showCookieBanner();
+
+            document.getElementById('accept-cookies').addEventListener('click', function() {
+                localStorage.setItem('analytics_consent', 'accepted');
+                loadGoogleAnalytics();
+                hideCookieBanner();
+            });
+
+            document.getElementById('decline-cookies').addEventListener('click', function() {
+                localStorage.setItem('analytics_consent', 'declined');
+                hideCookieBanner();
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add GA4 measurement ID support via environment variable
- show a consent banner and only load analytics after acceptance
- inject consent-gated analytics into generated map pages and document setup in the README